### PR TITLE
Remove storybook dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "lint": "tsdx lint",
     "prepare": "tsdx build",
     "size": "size-limit",
-    "analyze": "size-limit --why",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "analyze": "size-limit --why"
   },
   "peerDependencies": {
     "@walletconnect/client": ">=1.6.0",
@@ -54,11 +52,6 @@
     "@babel/core": "^7.14.8",
     "@rollup/plugin-image": "^2.1.0",
     "@size-limit/preset-small-lib": "^5.0.1",
-    "@storybook/addon-essentials": "^6.3.5",
-    "@storybook/addon-info": "^5.3.21",
-    "@storybook/addon-links": "^6.3.5",
-    "@storybook/addons": "^6.3.5",
-    "@storybook/react": "^6.3.5",
     "@types/qrcode": "^1.4.1",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",


### PR DESCRIPTION
Not using storybook here, so let's remove it (unless you have plans to use it). Seems like the example site is serving a similar purpose. 