### PR TITLE
Re-order deps and add eject .eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  "extends": [
+    "react-app",
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended"
+  ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "autoprefixer": "^10.3.1",
     "babel-loader": "^8.2.2",
     "cssnano": "^5.0.7",
+    "eslint-plugin-prettier": "^3.4.0",
     "husky": "^7.0.1",
     "postcss": "^8.3.6",
     "react": ">= 16.8.0",
@@ -68,8 +69,7 @@
     "size-limit": "^5.0.1",
     "tsdx": "^0.14.1",
     "tslib": "^2.3.0",
-    "typescript": "^4.3.5",
-    "eslint-plugin-prettier": "^3.4.0"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "@walletconnect/browser-utils": "^1.5.4",


### PR DESCRIPTION
Add an .eslintrc file so various editor linters know to activate. It was just the basic one tsdx generated. Also, yarn or npm re-ordered the dependencies list, so just capturing that. 