### PR TITLE
Use relative paths in example deploy

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "start": "parcel index.html",
-    "build-dev": "rm -rf dist/ && parcel build index.html --no-minify",
-    "build": "rm -rf dist/ && parcel build index.html",
+    "build-dev": "yarn run build --no-minify",
+    "build": "rm -rf dist/ && parcel build index.html --public-url ./",
     "push-gh-pages": "push-dir --dir=dist --branch=gh-pages --cleanup --verbose"
   },
   "dependencies": {


### PR DESCRIPTION
@estebanmino you were right. 

Small fix for the paths. I assumed parcel defaulted to this, but it defaults to `/` root paths for assets.

<img width="532" alt="Screen Shot 2021-08-25 at 2 33 33 PM" src="https://user-images.githubusercontent.com/166301/130860668-cf04fece-443c-41d5-a4f8-47908e1c7014.png">
